### PR TITLE
Support configuration with case format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 2.1.0 (2023-03-05)
+
+
+### Features
+
+* **Camelize:** cleanup camelize with vscode question ([86adfb3](https://github.com/ZouYouShun/vscode-index-generator/commit/86adfb38230c538cfcff6b1ab06fafbd188a6740))
+* **Command:** [OpenAndRun] support custom delay time ([2d561d1](https://github.com/ZouYouShun/vscode-index-generator/commit/2d561d1da121e2e6313cdb1c9aaf22bc5db22d6f))
+* **IndexGenerator:** support text format  when generate index file re-export content with configuration setting ([accd492](https://github.com/ZouYouShun/vscode-index-generator/commit/accd492fd3941e3c6555b5092b042391d1f82e75))
+* **Project:** cleanup whole project ([4c6ce02](https://github.com/ZouYouShun/vscode-index-generator/commit/4c6ce02cacd9a2c084fc41da729d36805b648e9d))
+
 ## 2.0.0 (2022-02-20)
 
 ✨ Release with standard-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [2.1.0](https://github.com/ZouYouShun/vscode-index-generator/compare/v2.0.0...v2.1.0) (2023-03-05)
+
+
+### Features
+
+* **IndexGenerator:** support text format  when generate index file re-export content with configuration setting ([1ba4040](https://github.com/ZouYouShun/vscode-index-generator/commit/1ba40405824d597e9edc99a6de6bbb944b2f1327))
+
 ## 2.1.0 (2023-03-05)
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,46 @@ View Feature Contributions to get all command that you can use
 | index-generator.switchCamelize            | switch word between camelize and underline                                   |
 | index-generator.toTs                      | Change files to ts.                                                          |
 | index-generator.changeExt                 | Change files extension from [source] to [target].                            |
-| index-generator.format                    | format all file with prettier and import sort(optional).                               |
+| index-generator.format                    | format all file with prettier and import sort(optional).                     |
 | index-generator.formatSortTsOnce          | format and sort with extensions.                                             |
 | index-generator.openAndRun                | open all files under folder and run command                                  |
+
+### Export default
+
+when we re-export from index, we use `camel case` to as that by default, like
+
+```ts
+export { default as FileName } from './file-name';
+```
+
+if you want to customize with different mode, you can set `index-generator.reExportDefaultCase` to change that format case (`lowerCamelCase`/`CamelCase`/`followFileName`).
+
+```json
+{
+  "index-generator.reExportDefaultCase": "followFileName"
+}
+```
+
+- CamelCase (default)
+
+```ts
+export { default as FileName } from './file-name';
+```
+
+- lowerCamelCase
+
+```ts
+export { default as fileName } from './file-name';
+```
+
+- followFileName (follow the first one character case format)
+
+```ts
+export { default as fileName } from './example-file-name';
+
+export { default as fileName } from './exampleFileName';
+
+export { default as FileName } from './Example-File-Name';
+
+export { default as FileName } from './ExampleFileName';
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "index-generator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "index-generator",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "format-imports": "^2.4.1",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -95,13 +95,24 @@
         "index-generator.firstLowerCase": {
           "type": "boolean",
           "default": true,
-          "description": "is the first word to be lowercase",
+          "description": "is the first word to be lowercase, use in `index-generator.switchCamelize`",
           "scope": "window"
         },
         "index-generator.camelizeSeparator": {
           "type": "string",
           "default": "_",
-          "description": "camelize separator char",
+          "description": "camelize separator char, use in `index-generator.switchCamelize`",
+          "scope": "window"
+        },
+        "index-generator.reExportDefaultCase": {
+          "type": "string",
+          "default": "camelCase",
+          "description": "when generating file with `default` export use that format to re-export.",
+          "enum": [
+            "camelCase",
+            "lowerCamelCase",
+            "followFileName"
+          ],
           "scope": "window"
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "publisher": "declanzou",
   "description": "Create index.ts(js) for folder.",
   "repository": "https://github.com/ZouYouShun/vscode-index-generator",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "icon": "icon.png",
   "engines": {
     "vscode": "^1.64.0"

--- a/src/commands/createIndex/utils/createIndex.ts
+++ b/src/commands/createIndex/utils/createIndex.ts
@@ -1,9 +1,14 @@
-import { OutputChannel } from './../../../utils/outputCannel';
 import * as vscode from 'vscode';
+
 import { IndexGenerator } from '../../../generator';
 import { IndexGeneratorOptions } from '../../../generator/IndexGeneratorOptions';
-import { askTargetFolder, getWorkspacePath } from '../../../utils';
+import {
+  askTargetFolder,
+  extensionNamespace,
+  getWorkspacePath,
+} from '../../../utils';
 import { getConfigs } from '../../../utils/extension/getConfigs';
+import { OutputChannel } from '../../../utils/outputCannel';
 
 export async function createIndex(
   type: IndexGeneratorOptions['type'] = 'both',
@@ -28,11 +33,18 @@ export async function createIndex(
         return;
       });
 
+      const reExportDefaultCase = vscode.workspace
+        .getConfiguration(extensionNamespace)
+        .get<IndexGeneratorOptions['reExportDefaultCase']>(
+          'reExportDefaultCase',
+        );
+
       const indexGenerator = new IndexGenerator(dirPath, {
         force: true,
         type,
         prettierConfig,
         ignore,
+        reExportDefaultCase,
         ...additionProps,
       });
 

--- a/src/generator/IndexGeneratorOptions.ts
+++ b/src/generator/IndexGeneratorOptions.ts
@@ -5,4 +5,5 @@ export type IndexGeneratorOptions = {
   ignore?: string;
   onlyTarget?: boolean;
   prettierConfig?: string;
+  reExportDefaultCase?: 'lowerCamelCase' | 'camelCase' | 'followFileName';
 };

--- a/src/utils/camelize.ts
+++ b/src/utils/camelize.ts
@@ -48,3 +48,9 @@ export function transformFirstCharacter(
 ): string {
   return processor(input[0]) + input.substring(1);
 }
+
+export const lowercaseCameCase = (fileName: string) => {
+  return transformFirstCharacter(camelize(fileName), (x) => {
+    return x.toLocaleLowerCase();
+  });
+};


### PR DESCRIPTION
https://github.com/ZouYouShun/vscode-index-generator/issues/11

support when generating file with `default` export use that format to re-export.